### PR TITLE
Make gem compatible with Ruby 1.9

### DIFF
--- a/delayed_job_recurring.gemspec
+++ b/delayed_job_recurring.gemspec
@@ -1,3 +1,5 @@
+require 'date'
+
 Gem::Specification.new do |s|
   s.name        = 'delayed_job_recurring'
   s.version     = '0.3.4'
@@ -11,7 +13,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/amitree/delayed_job_recurring'
   s.license     = 'MIT'
 
-  s.required_ruby_version = '~> 2.0'
+  s.required_ruby_version = '> 1.9'
 
   s.add_development_dependency 'rails'
   s.add_development_dependency 'rspec', '3.0.0'

--- a/lib/delayed/recurring_job.rb
+++ b/lib/delayed/recurring_job.rb
@@ -183,7 +183,7 @@ module Delayed
       end
 
       def inherited(subclass)
-        %i(@run_at @run_interval @tz @priority).each do |var|
+        [:@run_at, :@run_interval, :@tz, :@priority].each do |var|
           next unless instance_variable_defined? var
           subclass.instance_variable_set var, self.instance_variable_get(var)
           subclass.instance_variable_set "#{var}_inherited", true


### PR DESCRIPTION
I recently ran into some parallel computing issues with the clockwork gem. After some research we decided to use your gem to solve our problems by leaning on delayed jobs (which we already have in the app).

I came upon a few things that I thought would be worth adjusting in the gem. I hope you don't mind! Of course, I'm happy to hear your feedback and make any changes necessary to meet your liking :+1: 

---

Our app is a little legacy at this point, so we're still running Ruby 1.9. As it turns out, your library is written well and only a small change allows it to be compatible with Ruby 1.9!

What do you think? :blush:
