### PR TITLE
Recommend "safe" schedule for use in initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ end
 And schedule it. In a rails app, you might put this in an initializer:
 
 ```ruby
-MyTask.schedule! # run every day at 11am Pacific time (accounting for daylight savings)
+MyTask.schedule # run every day at 11am Pacific time (accounting for daylight savings)
 ```
 
 ## Advanced usage


### PR DESCRIPTION
* The bang version removes any existing jobs before scheduling a new
  one. This has been known to create a race condition on the server.
  Each delayed job worker loads the app which loads initializers. When
  this method is called, existing jobs are deleted which effectively
  prevents any existing recurring job from being invoked by the delayed
  job worker that is loading.

---

Does that make sense? We're still in the process of verifying this in our app.