### PR TITLE
Ensure singular enqueued jobs in multi-process environment

### DIFF
--- a/lib/delayed/recurring_job.rb
+++ b/lib/delayed/recurring_job.rb
@@ -40,10 +40,14 @@ module Delayed
       enqueue_opts = { priority: @schedule_options[:priority], run_at: next_run_time }
       enqueue_opts[:queue] = @schedule_options[:queue] if @schedule_options[:queue]
 
-      if Gem.loaded_specs['delayed_job'].version.to_s.first.to_i < 3
-        Delayed::Job.enqueue self, enqueue_opts[:priority], enqueue_opts[:run_at]
-      else
-        Delayed::Job.enqueue self, enqueue_opts
+      Delayed::Job.transaction do
+        self.class.jobs.destroy_all
+
+        if Gem.loaded_specs['delayed_job'].version.to_s.first.to_i < 3
+          Delayed::Job.enqueue self, enqueue_opts[:priority], enqueue_opts[:run_at]
+        else
+          Delayed::Job.enqueue self, enqueue_opts
+        end
       end
     end
 


### PR DESCRIPTION
An example of such as case is (for ease of development/testing) having a recurring job scheduled in an initializer. It is possible to have a situation where DJ spools up a previously scheduled job, then (possibly due to a longer load time) another process runs its initializer also scheduling up a new job. Then when the running job finishes, it schedules itself resulting in two of the same job in DJ