### PR TITLE
Scheduling multiple jobs of same class

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ MyTask.schedule(run_every: 1.week, run_at: ['sunday 8:00am', 'wednesday 8:00am']
 
 By default, before scheduling a new job, the old jobs scheduled with the same class will be unscheduled. 
 
-To schedule multiple jobs with same class, pass an unique matching param (`job_matching_param`) and value for that matching param in each job as below:
+To schedule multiple jobs with same class, pass an unique matching param `job_matching_param` and value for that matching param in each job as below:
 
 ```ruby
 MyTask.schedule(run_at: '12:00', job_matching_param: 'schedule_id', schedule_id: 2)
 ```
 
-This allows you to schedule multiple jobs with same class if value of the unique matching param (`job_matching_param`) is different in each job which is `schedule_id` in above example.
+This allows you to schedule multiple jobs with same class if value of the unique matching param which is `schedule_id` in above example is different in each job.
 
 ## Thanks!
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ MyTask.schedule(run_every: 1.day, run_at: ['11:00', '6:00pm']
 MyTask.schedule(run_every: 1.week, run_at: ['sunday 8:00am', 'wednesday 8:00am'])
 ```
 
+### Scheduling multiple jobs of same class
+
+By default, before scheduling a new job, the old jobs scheduled with the same class will be unscheduled. 
+
+To schedule multiple jobs with same class, pass an unique matching param and value for that matching param in each job as below:
+
+```ruby
+MyTask.schedule(run_at: '12:00', job_matching_param: 'schedule_id', schedule_id: 2)
+```
+
+This allows you to schedule multiple jobs with same class if value of the param `schedule_id`(job_matching_param) is different.
+
 ## Thanks!
 
 Many thanks to @ginjo and @kares for their work!  This code was derived from https://gist.github.com/ginjo/3688965.

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ MyTask.schedule(run_every: 1.week, run_at: ['sunday 8:00am', 'wednesday 8:00am']
 
 By default, before scheduling a new job, the old jobs scheduled with the same class will be unscheduled. 
 
-To schedule multiple jobs with same class, pass an unique matching param and value for that matching param in each job as below:
+To schedule multiple jobs with same class, pass an unique matching param (`job_matching_param`) and value for that matching param in each job as below:
 
 ```ruby
 MyTask.schedule(run_at: '12:00', job_matching_param: 'schedule_id', schedule_id: 2)
 ```
 
-This allows you to schedule multiple jobs with same class if value of the param `schedule_id`(job_matching_param) is different.
+This allows you to schedule multiple jobs with same class if value of the unique matching param (`job_matching_param`) is different in each job which is `schedule_id` in above example.
 
 ## Thanks!
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To schedule multiple jobs with same class, pass an unique matching param `job_ma
 MyTask.schedule(run_at: '12:00', job_matching_param: 'schedule_id', schedule_id: 2)
 ```
 
-This allows you to schedule multiple jobs with same class if value of the unique matching param(which is `schedule_id` in above example is different in each job.
+This allows you to schedule multiple jobs with same class if value of the unique matching param(which is `schedule_id` in above example) is different in each job.
 
 ## Thanks!
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ To schedule multiple jobs with same class, pass an unique matching param `job_ma
 MyTask.schedule(run_at: '12:00', job_matching_param: 'schedule_id', schedule_id: 2)
 ```
 
-This allows you to schedule multiple jobs with same class if value of the unique matching param which is `schedule_id` in above example is different in each job.
+This allows you to schedule multiple jobs with same class if value of the unique matching param(which is `schedule_id` in above example is different in each job.
 
 ## Thanks!
 

--- a/delayed_job_recurring.gemspec
+++ b/delayed_job_recurring.gemspec
@@ -2,7 +2,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'delayed_job_recurring'
-  s.version     = '0.3.6'
+  s.version     = '0.3.7'
   s.date        = Date.today.to_s
   s.summary     = "Recurring jobs for delayed_job"
   s.description = "Extends delayed_job to support recurring jobs, including timezone support"

--- a/lib/delayed/recurring_job.rb
+++ b/lib/delayed/recurring_job.rb
@@ -164,10 +164,11 @@ module Delayed
       def jobs(options = {})
         options = options.with_indifferent_access
 
+        # Construct dynamic query with 'job_matching_param' if present
         query = ["((handler LIKE ?) OR (handler LIKE ?))", "--- !ruby/object:#{name} %", "--- !ruby/object:#{name}\n%"]
         if options[:job_matching_param].present?
           matching_key = options[:job_matching_param]
-          matching_value = options[options[:job_matching_param]]
+          matching_value = options[matching_key]
           query[0] = "#{query[0]} AND handler LIKE ?"
           query << "%#{matching_key}: #{matching_value}%"
         end

--- a/lib/delayed/recurring_job.rb
+++ b/lib/delayed/recurring_job.rb
@@ -41,8 +41,7 @@ module Delayed
       enqueue_opts[:queue] = @schedule_options[:queue] if @schedule_options[:queue]
 
       Delayed::Job.transaction do
-        options = options.presence || @schedule_options
-        self.class.jobs(options).destroy_all
+        self.class.jobs(@schedule_options).destroy_all
         if Gem.loaded_specs['delayed_job'].version.to_s.first.to_i < 3
           Delayed::Job.enqueue self, enqueue_opts[:priority], enqueue_opts[:run_at]
         else


### PR DESCRIPTION
In reference to issue #17, 

Added option to schedule multiple jobs with same class by differentiating with an unique param `job_matching_param`.

To schedule multiple jobs with same class, pass an unique matching param `job_matching_param` and value for that matching param in each job as below:

```ruby
MyTask.schedule(run_at: '12:00', job_matching_param: 'schedule_id', schedule_id: 2)
```

This allows you to schedule multiple jobs with same class if value of the unique matching param(which is `schedule_id` in above example) is different in each job.
