### PR TITLE
Allow Additional Delayed Job Options Into Schedule

### DIFF
--- a/lib/delayed/recurring_job.rb
+++ b/lib/delayed/recurring_job.rb
@@ -37,8 +37,9 @@ module Delayed
         queue: self.class.queue
       )
 
-      enqueue_opts = { priority: @schedule_options[:priority], run_at: next_run_time }
-      enqueue_opts[:queue] = @schedule_options[:queue] if @schedule_options[:queue]
+      base_opts = {run_at: next_run_time}
+      filtered_schedule_options = @schedule_options.except(:run_at, :timezone, :run_interval)
+      enqueue_opts = base_opts.merge(filtered_schedule_options)
 
       Delayed::Job.transaction do
         self.class.jobs(@schedule_options).destroy_all


### PR DESCRIPTION
Currently, you cannot pass in additional parameters to the Delayed:Job through the schedule method. In a project I'm working on, we have an additional database field for our delayed jobs. This allows us to pass in that field as a parameter into schedule.

I'd love feedback on these changes.