### PR TITLE
Allows usage of ISO8601 Duration strings for `run_every`

### DIFF
--- a/lib/delayed/recurring_job.rb
+++ b/lib/delayed/recurring_job.rb
@@ -84,6 +84,8 @@ module Delayed
       case serialized
       when Hash
         ActiveSupport::Duration.new(serialized[:value], serialized[:parts])
+      when /^P/
+        ActiveSupport::Duration.parse(serialized)
       else
         serialized
       end


### PR DESCRIPTION
I have an interesting use case where I'm making a GraphQL API for creating recurring background jobs. Rather than have to dangerously exec Ruby syntax for setting durations like `1.month` I discovered that the ISO8601 spec has support for Durations. For example `P1M` is equivalent to `1.month`. This PR adds support for this syntax in addition to ActiveSupport::Duration and integers. It uses the built-in support for ISO Duration parsing available with `ActiveSupport::Duration.parse`

I just do a simple regex check that the `run_every` object is a String starting with a `P` and let the parser take it from there. If there are any syntax errors they will be found by the AS::Duration parser.

I didn't add any specs because I didn't know if this was something the maintainers would even be interested in supporting. If so, let me know and I'll add specs and update the docs!